### PR TITLE
#9: Add a function to calculate average points bet on a game

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,14 +11,11 @@
     "test": "jest -i"
   },
   "devDependencies": {
-    "@types/chai": "^4.3.3",
     "@types/jest": "^29.0.1",
     "jest": "^29.0.3",
     "ts-jest": "^29.0.0",
     "ts-node": "^10.9.1",
     "typescript": "^4.8.3"
   },
-  "dependencies": {
-    "chai": "^4.3.6"
-  }
+  "dependencies": {}
 }

--- a/spec/data/spreadConversion.spec.ts
+++ b/spec/data/spreadConversion.spec.ts
@@ -1,24 +1,23 @@
-import { expect } from 'chai'
 import spreadToWinPercent from '../../src/data/spreadConversion';
 
 describe(spreadToWinPercent, () => { 
   it('gives a 0.5 win chance when spread is 0', () => {
-    expect(spreadToWinPercent(0)).to.eq(0.5);
+    expect(spreadToWinPercent(0)).toBe(0.5);
   })
   
   it ('gives a 0 win chance when spread is 17', () => {
-    expect(spreadToWinPercent(17)).to.eq(0);
+    expect(spreadToWinPercent(17)).toBe(0);
   })
 
   it ('gives a 0 win chance when spread is greater than 17', () => {
-    expect(spreadToWinPercent(20)).to.eq(0);
+    expect(spreadToWinPercent(20)).toBe(0);
   })
 
   it ('gives a 1 win chance when spread is -17', () => {
-    expect(spreadToWinPercent(-17)).to.eq(1);
+    expect(spreadToWinPercent(-17)).toBe(1);
   })
   
   it ('gives a 1 win chance when spread is less than -17', () => {
-    expect(spreadToWinPercent(-20)).to.eq(1);
+    expect(spreadToWinPercent(-20)).toBe(1);
   })
 })

--- a/spec/data/teamConversion.spec.ts
+++ b/spec/data/teamConversion.spec.ts
@@ -1,20 +1,19 @@
-import { expect } from 'chai'
 import ofpTeamToOddsApiTeam from '../../src/data/teamConversion';
 
 describe(ofpTeamToOddsApiTeam, () => {
   it('works for a matching lowercase team name', () => {
-    expect(ofpTeamToOddsApiTeam('arizona')).to.eq('arizona cardinals');
+    expect(ofpTeamToOddsApiTeam('arizona')).toBe('arizona cardinals');
   })
 
   it('works for a matching capitalized team name', () => {
-    expect(ofpTeamToOddsApiTeam('Arizona')).to.eq('arizona cardinals');
+    expect(ofpTeamToOddsApiTeam('Arizona')).toBe('arizona cardinals');
   })
 
   it('works for a matching mixed case team name', () => {
-    expect(ofpTeamToOddsApiTeam('AriZonA')).to.eq('arizona cardinals');
+    expect(ofpTeamToOddsApiTeam('AriZonA')).toBe('arizona cardinals');
   })
 
   it('returns undefined for non-matching team name', () => {
-    expect(ofpTeamToOddsApiTeam('edmonton')).to.be.undefined;
+    expect(ofpTeamToOddsApiTeam('edmonton')).toBeUndefined;
   })
 })

--- a/spec/utils/game.spec.ts
+++ b/spec/utils/game.spec.ts
@@ -1,0 +1,21 @@
+import { avgGamePoints } from '../../src/utils/game';
+import { GameData } from '../../src/@types/gameData';
+
+const testGame: GameData = [
+  {
+    name: 'Away Team',
+    pointDist: 0.01,
+    winProb: 0.25,
+  },
+  {
+    name: 'Home Team',
+    pointDist: 0.02,
+    winProb: 0.75,
+  },
+]
+
+describe(avgGamePoints, () => {
+  it('correctly calculates the average points bet on a game', () => {
+    expect(avgGamePoints(testGame, 100)).toBe(1.75)
+  })
+})

--- a/src/@types/gameData.ts
+++ b/src/@types/gameData.ts
@@ -1,0 +1,7 @@
+interface TeamData {
+  name: string
+  pointDist: number
+  winProb: number
+};
+
+export type GameData = [TeamData, TeamData];

--- a/src/utils/game.ts
+++ b/src/utils/game.ts
@@ -1,0 +1,8 @@
+import { GameData } from "../@types/gameData";
+
+export const avgGamePoints = (game: GameData, totalPoints: number) => {
+  const awayPoints = game[0].pointDist * game[0].winProb * totalPoints
+  const homePoints = game[1].pointDist * game[1].winProb * totalPoints
+
+  return +(awayPoints + homePoints).toFixed(3)
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -633,11 +633,6 @@
   dependencies:
     "@babel/types" "^7.3.0"
 
-"@types/chai@^4.3.3":
-  version "4.3.3"
-  resolved "https://registry.yarnpkg.com/@types/chai/-/chai-4.3.3.tgz#3c90752792660c4b562ad73b3fbd68bf3bc7ae07"
-  integrity sha512-hC7OMnszpxhZPduX+m+nrx+uFoLkWOMiR4oa/AZF3MuSETYTZmFfJAHqZEM8MVlvfG7BEUcgvtwoCTxBp6hm3g==
-
 "@types/graceful-fs@^4.1.3":
   version "4.1.5"
   resolved "https://registry.yarnpkg.com/@types/graceful-fs/-/graceful-fs-4.1.5.tgz#21ffba0d98da4350db64891f92a9e5db3cdb4e15"
@@ -759,11 +754,6 @@ argparse@^1.0.7:
   integrity sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==
   dependencies:
     sprintf-js "~1.0.2"
-
-assertion-error@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/assertion-error/-/assertion-error-1.1.0.tgz#e60b6b0e8f301bd97e5375215bda406c85118c0b"
-  integrity sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==
 
 babel-jest@^29.0.3:
   version "29.0.3"
@@ -894,19 +884,6 @@ caniuse-lite@^1.0.30001370:
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001397.tgz#010d9d56e3b8abcd8df261d0a94b22426271a15f"
   integrity sha512-SW9N2TbCdLf0eiNDRrrQXx2sOkaakNZbCjgNpPyMJJbiOrU5QzMIrXOVMRM1myBXTD5iTkdrtU/EguCrBocHlA==
 
-chai@^4.3.6:
-  version "4.3.6"
-  resolved "https://registry.yarnpkg.com/chai/-/chai-4.3.6.tgz#ffe4ba2d9fa9d6680cc0b370adae709ec9011e9c"
-  integrity sha512-bbcp3YfHCUzMOvKqsztczerVgBKSsEijCySNlHHbX3VG1nskvqjz5Rfso1gGwD6w6oOV3eI60pKuMOV5MV7p3Q==
-  dependencies:
-    assertion-error "^1.1.0"
-    check-error "^1.0.2"
-    deep-eql "^3.0.1"
-    get-func-name "^2.0.0"
-    loupe "^2.3.1"
-    pathval "^1.1.1"
-    type-detect "^4.0.5"
-
 chalk@^2.0.0:
   version "2.4.2"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.2.tgz#cd42541677a54333cf541a49108c1432b44c9424"
@@ -928,11 +905,6 @@ char-regex@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/char-regex/-/char-regex-1.0.2.tgz#d744358226217f981ed58f479b1d6bcc29545dcf"
   integrity sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==
-
-check-error@^1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/check-error/-/check-error-1.0.2.tgz#574d312edd88bb5dd8912e9286dd6c0aed4aac82"
-  integrity sha512-BrgHpW9NURQgzoNyjfq0Wu6VFO6D7IZEmJNdtgNqpzGG8RuNFHt2jQxWlAs4HMe119chBnv+34syEZtc6IhLtA==
 
 ci-info@^3.2.0:
   version "3.4.0"
@@ -1024,13 +996,6 @@ dedent@^0.7.0:
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/dedent/-/dedent-0.7.0.tgz#2495ddbaf6eb874abb0e1be9df22d2e5a544326c"
   integrity sha512-Q6fKUPqnAHAyhiUgFU7BUzLiv0kd8saH9al7tnu5Q/okj6dnupxyTgFIBjVzJATdfIAm9NAsvXNzjaKa+bxVyA==
-
-deep-eql@^3.0.1:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/deep-eql/-/deep-eql-3.0.1.tgz#dfc9404400ad1c8fe023e7da1df1c147c4b444df"
-  integrity sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==
-  dependencies:
-    type-detect "^4.0.0"
 
 deepmerge@^4.2.2:
   version "4.2.2"
@@ -1176,11 +1141,6 @@ get-caller-file@^2.0.5:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-2.0.5.tgz#4f94412a82db32f36e3b0b9741f8a97feb031f7e"
   integrity sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==
-
-get-func-name@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/get-func-name/-/get-func-name-2.0.0.tgz#ead774abee72e20409433a066366023dd6887a41"
-  integrity sha512-Hm0ixYtaSZ/V7C8FJrtZIuBBI+iSgL+1Aq82zSu8VQNB4S3Gk8e7Qs3VwBDJAhmRZcFqkl3tQu36g/Foh5I5ig==
 
 get-package-type@^0.1.0:
   version "0.1.0"
@@ -1760,13 +1720,6 @@ lodash.memoize@4.x:
   resolved "https://registry.yarnpkg.com/lodash.memoize/-/lodash.memoize-4.1.2.tgz#bcc6c49a42a2840ed997f323eada5ecd182e0bfe"
   integrity sha512-t7j+NzmgnQzTAYXcsHYLgimltOV1MXHtlOWf6GjL9Kj8GK5FInw5JotxvbOs+IvV1/Dzo04/fCGfLVs7aXb4Ag==
 
-loupe@^2.3.1:
-  version "2.3.4"
-  resolved "https://registry.yarnpkg.com/loupe/-/loupe-2.3.4.tgz#7e0b9bffc76f148f9be769cb1321d3dcf3cb25f3"
-  integrity sha512-OvKfgCC2Ndby6aSTREl5aCCPTNIzlDfQZvZxNUrBrihDhL3xcrYegTblhmEiCrg2kKQz4XsFIaemE5BF4ybSaQ==
-  dependencies:
-    get-func-name "^2.0.0"
-
 lru-cache@^6.0.0:
   version "6.0.0"
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-6.0.0.tgz#6d6fe6570ebd96aaf90fcad1dafa3b2566db3a94"
@@ -1919,11 +1872,6 @@ path-parse@^1.0.7:
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.7.tgz#fbc114b60ca42b30d9daf5858e4bd68bbedb6735"
   integrity sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==
-
-pathval@^1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/pathval/-/pathval-1.1.1.tgz#8534e77a77ce7ac5a2512ea21e0fdb8fcf6c3d8d"
-  integrity sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==
 
 picocolors@^1.0.0:
   version "1.0.0"
@@ -2209,7 +2157,7 @@ ts-node@^10.9.1:
     v8-compile-cache-lib "^3.0.1"
     yn "3.1.1"
 
-type-detect@4.0.8, type-detect@^4.0.0, type-detect@^4.0.5:
+type-detect@4.0.8:
   version "4.0.8"
   resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-4.0.8.tgz#7646fb5f18871cfbb7749e69bd39a6388eb7450c"
   integrity sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==


### PR DESCRIPTION
Note: Also removed the chai matcher library because jest has it's own.